### PR TITLE
[Feature] Fanout for RemoteData

### DIFF
--- a/remotedata/src/main/java/com/mercari/remotedata/RemoteData.kt
+++ b/remotedata/src/main/java/com/mercari/remotedata/RemoteData.kt
@@ -113,3 +113,9 @@ fun <V : Any, E : Exception, EE : Exception> RemoteData<V, E>.flatMapError(
             is RemoteData.Success -> this
             is RemoteData.Failure -> transform(error)
         }
+
+fun <U : Any, V : Any, E : Exception> RemoteData<U, E>.fanout(anotherRemoteData: RemoteData<V, E>): RemoteData<Pair<U, V>, E> =
+        fanout(anotherRemoteData, ::Pair)
+
+fun <U : Any, V : Any, T : Any, E : Exception> RemoteData<U, E>.fanout(anotherRemoteData: RemoteData<V, E>, transform: (U, V) -> T) =
+        flatMap { outer -> anotherRemoteData.map { inner -> transform(outer, inner) } }

--- a/remotedata/src/test/java/com/mercari/remotedata/RemoteDataTest.kt
+++ b/remotedata/src/test/java/com/mercari/remotedata/RemoteDataTest.kt
@@ -79,6 +79,27 @@ class RemoteDataTest : Spek({
             val value = remoteData.getOrElse(40)
             value shouldEqual 42
         }
+
+        it("fanout return a pair of values") {
+            val anotherRm = RemoteData.Success(28)
+
+            val (value, error) = remoteData.fanout(anotherRm)
+
+            value!!.first shouldEqual 42
+            value.second shouldEqual 28
+            error.shouldBeNull()
+        }
+
+        data class Foo(val value1: Int, val value2: String)
+
+        it("fanout with a custom transform block") {
+            val anotherRm = RemoteData.Success(28)
+
+            val fanout = remoteData.fanout(anotherRm) { one, two -> Foo(one, two.toString()) }
+
+            fanout.get()!!.value1 shouldEqual 42
+            fanout.get()!!.value2 shouldEqual "28"
+        }
     }
 
     describe("failure remote data") {
@@ -154,6 +175,16 @@ class RemoteDataTest : Spek({
             val value = remoteData.getOrElse(40)
             value shouldEqual 40
         }
+
+        it("fanout does not return a pair of values") {
+            val anotherRm = RemoteData.Success(28)
+
+            val (value, error) = remoteData.fanout(anotherRm)
+
+            value.shouldBeNull()
+            error!!.shouldBeInstanceOf<IllegalStateException>()
+            error.message shouldEqual "Not Available"
+        }
     }
 
     describe("notAsked remote data") {
@@ -200,6 +231,15 @@ class RemoteDataTest : Spek({
             val (value, error) = remoteData.mapBoth({ it }, { NullPointerException() })
             value.shouldBeNull()
             error.shouldBeNull()
+        }
+
+        it("fanout does not return a pair of values") {
+            val anotherRm = RemoteData.Success(28)
+
+            val fanout = remoteData.fanout(anotherRm)
+
+            fanout shouldBe RemoteData.NotAsked
+            fanout.get().shouldBeNull()
         }
     }
 
@@ -272,6 +312,19 @@ class RemoteDataTest : Spek({
 
         it("maps both to new types correctly") {
             val (value, error) = rmString.mapBoth({ it.count() }, { NullPointerException() })
+            value.shouldBeNull()
+            error.shouldBeNull()
+        }
+
+        it("fanout does not return a pair of values") {
+            val anotherRm = RemoteData.Success(28)
+
+            val fanout = rmInt.fanout(anotherRm)
+
+            fanout.shouldBeInstanceOf<RemoteData.Loading<*>>()
+
+            val (value, error) = fanout
+
             value.shouldBeNull()
             error.shouldBeNull()
         }

--- a/remotedata/src/test/java/com/mercari/remotedata/RemoteDataTest.kt
+++ b/remotedata/src/test/java/com/mercari/remotedata/RemoteDataTest.kt
@@ -75,12 +75,12 @@ class RemoteDataTest : Spek({
             error.shouldBeNull()
         }
 
-        it("getOrElse return value correctly") {
+        it("getOrElse returns value correctly") {
             val value = remoteData.getOrElse(40)
             value shouldEqual 42
         }
 
-        it("fanout return a pair of values") {
+        it("fanout returns a pair of values") {
             val anotherRm = RemoteData.Success(28)
 
             val (value, error) = remoteData.fanout(anotherRm)
@@ -92,7 +92,7 @@ class RemoteDataTest : Spek({
 
         data class Foo(val value1: Int, val value2: String)
 
-        it("fanout with a custom transform block") {
+        it("fanout multiple rm with a custom transform block") {
             val anotherRm = RemoteData.Success(28)
 
             val fanout = remoteData.fanout(anotherRm) { one, two -> Foo(one, two.toString()) }


### PR DESCRIPTION
### What's in this PR?

This PR adds `fanout` to RemoteData. This is to add an ability to combine multiple RemoteData together.

### Usage

``` kotlin
val oneRm = RemoteData.Success(42)
val twoRm = RemoteData.Success(28)

val (v, e) = oneRm.fanout(twoRm)

// v will produce Pair(42, 28)
// e will be null as usual
```