### PR TITLE
Completeness trait

### DIFF
--- a/remotedata/src/main/java/com/mercari/remotedata/RemoteData.kt
+++ b/remotedata/src/main/java/com/mercari/remotedata/RemoteData.kt
@@ -13,12 +13,12 @@ sealed class RemoteData<out V : Any, out E : Exception> {
 
     open fun get(): V? = null
 
-    object NotAsked : RemoteData<Nothing, Nothing>()
+    object NotAsked : RemoteData<Nothing, Nothing>(), Incomplete
 
     class Loading<V : Any> @JvmOverloads constructor(
             progress: Int? = null,
             val totalUnits: Int = 100
-    ) : RemoteData<V, Nothing>() {
+    ) : RemoteData<V, Nothing>(), Incomplete {
 
         var progress: Int? = progress?.coerceTo(totalUnits)
             set(value) {
@@ -39,7 +39,7 @@ sealed class RemoteData<out V : Any, out E : Exception> {
                 (javaClass.hashCode() * 31 + progress?.plus(1).hashCode()) * 31 + totalUnits.hashCode()
     }
 
-    class Success<out V : Any>(val value: V) : RemoteData<V, Nothing>() {
+    class Success<out V : Any>(val value: V) : RemoteData<V, Nothing>(), Complete {
 
         override fun component1(): V = value
 
@@ -54,7 +54,7 @@ sealed class RemoteData<out V : Any, out E : Exception> {
         override fun hashCode(): Int = javaClass.hashCode() * 31 + value.hashCode()
     }
 
-    class Failure<out E : Exception>(val error: E) : RemoteData<Nothing, E>() {
+    class Failure<out E : Exception>(val error: E) : RemoteData<Nothing, E>(), Complete {
 
         override fun component2(): E = error
 
@@ -68,6 +68,10 @@ sealed class RemoteData<out V : Any, out E : Exception> {
 
         override fun hashCode(): Int = javaClass.hashCode() * 31 + error.hashCode()
     }
+
+    interface Complete
+
+    interface Incomplete
 
     val isNotAsked
         get() = this is NotAsked

--- a/remotedata/src/test/java/com/mercari/remotedata/RemoteDataTest.kt
+++ b/remotedata/src/test/java/com/mercari/remotedata/RemoteDataTest.kt
@@ -6,7 +6,6 @@ import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldNotEqual
-import org.amshove.kluent.shouldNotThrow
 import org.amshove.kluent.shouldThrow
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -32,6 +31,10 @@ class RemoteDataTest : Spek({
             val anotherSuccess = RemoteData.Success(43)
             remoteData.hashCode() shouldNotEqual anotherSuccess.hashCode()
             remoteData shouldNotEqual anotherSuccess
+        }
+
+        it("completeness") {
+            remoteData shouldBeInstanceOf RemoteData.Complete::class
         }
 
         it("reports Success") {
@@ -128,6 +131,10 @@ class RemoteDataTest : Spek({
             remoteData shouldNotEqual anotherFailure
         }
 
+        it("completeness") {
+            remoteData shouldBeInstanceOf RemoteData.Complete::class
+        }
+
         it("reports failure") {
             remoteData.run {
                 isSuccess shouldEqual false
@@ -195,10 +202,14 @@ class RemoteDataTest : Spek({
             remoteData.get().shouldBeNull()
         }
 
-        it("equal to another") {
+        it("equality") {
             val anotherNotAsked = RemoteData.NotAsked
             remoteData.hashCode() shouldEqual anotherNotAsked.hashCode()
             remoteData shouldEqual anotherNotAsked
+        }
+
+        it("completeness") {
+            remoteData shouldBeInstanceOf RemoteData.Incomplete::class
         }
 
         it("reports notAsked") {
@@ -259,7 +270,7 @@ class RemoteDataTest : Spek({
             rmString.get().shouldBeNull()
         }
 
-        it("tests equality") {
+        it("equality") {
             val sameLoading = RemoteData.Loading<Int>()
             rmInt.hashCode() shouldEqual sameLoading.hashCode()
             rmInt shouldEqual sameLoading
@@ -282,6 +293,11 @@ class RemoteDataTest : Spek({
 
             indeterminateRmBytes.hashCode() shouldEqual otherIndeterminateRmBytes.hashCode()
             indeterminateRmBytes shouldEqual otherIndeterminateRmBytes
+        }
+
+        it("completeness") {
+            rmInt shouldBeInstanceOf RemoteData.Incomplete::class
+            determinateRmBytesWithTotal shouldBeInstanceOf RemoteData.Incomplete::class
         }
 
         it("has no value at creation but the type is carried along properly") {


### PR DESCRIPTION
This adds a completeness trait for convenience.

In case we would like to just handle state transitions by completeness.

For example:
```kotlin
var data: RemoteData<ByteArray>

when (data) {
   is Incomplete -> foo()
   is Complete   -> process(data)
}
```