### PR TITLE
Move constant properties from gradle.properties to buildSrc config file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,9 +6,9 @@ buildscript {
     }
 
     dependencies {
-        classpath(kotlin("gradle-plugin", extra.get("kotlinVersion") as String))
-        classpath("org.junit.platform:junit-platform-gradle-plugin:${extra.get("junitPlatformVersion")}")
-        classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:${extra.get("bintrayVersion")}")
+        classpath(kotlin(Classpath.kotlin, Version.kotlin))
+        classpath(Classpath.junitPlatform)
+        classpath(Classpath.bintray)
     }
 }
 
@@ -16,7 +16,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { setUrl("https://dl.bintray.com/spekframework/spek-dev") }
+        maven { setUrl(MavenUrl.spekDev) }
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,12 @@
+repositories {
+  jcenter()
+}
+
+plugins {
+  `kotlin-dsl`
+  `java-gradle-plugin`
+}
+
+dependencies {
+  implementation(gradleApi())
+}

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -15,7 +15,7 @@ object Version {
   const val kluent = "1.49"
   const val spek = "2.0.1"
   const val junitPlatform = "1.2.0"
-  const val jacoco = "0.8.4"
+  const val jacoco = "0.8.3"
 }
 
 object Classpath {

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,0 +1,35 @@
+import org.gradle.kotlin.dsl.extra
+
+object Artifact {
+  const val groupdId = "com.mercari.remotedata"
+  const val version = "1.0.0"
+}
+
+object MavenUrl {
+  const val spekDev = "https://dl.bintray.com/spekframework/spek-dev"
+}
+
+object Version {
+  const val bintray = "1.8.4"
+  const val kotlin = "1.3.10"
+  const val kluent = "1.49"
+  const val spek = "2.0.1"
+  const val junitPlatform = "1.2.0"
+  const val jacoco = "0.8.4"
+}
+
+object Classpath {
+  const val kotlin = "gradle-plugin"
+  const val junitPlatform = "org.junit.platform:junit-platform-gradle-plugin:${Version.junitPlatform}"
+  const val bintray = "com.jfrog.bintray.gradle:gradle-bintray-plugin:${Version.bintray}"
+}
+
+object Dependencies {
+  const val kotlin = "stdlib"
+}
+
+object TestDependencies {
+  const val kluent = "org.amshove.kluent:kluent-android:${Version.kluent}"
+  const val spek = "org.spekframework.spek2:spek-dsl-jvm:${Version.spek}"
+  const val spekRunner = "org.spekframework.spek2:spek-runner-junit5:${Version.spek}"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,17 +11,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-# Publishing
-artifactGroupId=com.mercari.remotedata
-artifactPublishVersion=1.0.0
-bintrayVersion=1.8.4
-
-# Compile
-kotlinVersion=1.3.10
-
-# Test
-junitPlatformVersion=1.2.0
-kluentVersion=1.49
-spekVersion=2.0.1
-

--- a/remotedata/build.gradle.kts
+++ b/remotedata/build.gradle.kts
@@ -13,16 +13,14 @@ repositories {
 }
 
 dependencies {
-    val kotlinVersion = extra.get("kotlinVersion") as String
-    implementation(kotlin("stdlib", kotlinVersion))
+    implementation(kotlin(Dependencies.kotlin, Version.kotlin))
 
     // assertion
-    testImplementation("org.amshove.kluent:kluent-android:${extra.get("kluentVersion") as String}")
+    testImplementation(TestDependencies.kluent)
 
     //spek2
-    val spekVersion = extra.get("spekVersion") as String
-    testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
+    testImplementation(TestDependencies.spek)
+    testRuntimeOnly(TestDependencies.spekRunner)
 }
 
 jacoco {
@@ -57,8 +55,8 @@ task<JacocoReport>("codeCoverageReport") {
     dependsOn(junitPlatformTest)
 }
 
-val artifactGroupId = extra.get("artifactGroupId") as String
-val artifactPublishVersion = extra.get("artifactPublishVersion") as String
+val artifactGroupId = Artifact.groupdId
+val artifactPublishVersion = Artifact.version
 
 group = artifactGroupId
 version = artifactPublishVersion

--- a/remotedata/build.gradle.kts
+++ b/remotedata/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 }
 
 jacoco {
-    toolVersion = "0.8.3"
+    toolVersion = Version.jacoco
 
     val junitPlatformTest: JavaExec by tasks
     applyTo(junitPlatformTest)


### PR DESCRIPTION
As there are many `extra` field generated by the extension of `ExtensionAware` in Kotlin DSL, it's confusing which one should be suitable for reading properties in `gradle.properties`.
And we don't overwrite values with other configuration such as environment variables, so it is not necessary to use `gradle.properties` file.
So this will relocate constant properties in `gradle.properties` into `buildSrc/src/main/kotlin/Config.kt`.