### PR TITLE
Fix deploy environment on CircleCI for android deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run: ./gradlew clean :remotedata:build :remotedata:bintrayUpload -PBINTRAY_USER=$BINTRAY_USER -PBINTRAY_KEY=$BINTRAY_KEY -PdryRun=false -Ppublish=true
 
   deploy-android:
-    <<: *jdk_env
+    <<: *android_env
     steps:
       - checkout
 


### PR DESCRIPTION
It was supposed to be `android_env` but actually `jdk_env` and caused `no sdk location` error during deployment job. 