### PR TITLE
Prepare 1.0.1 release

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -2,7 +2,7 @@ import org.gradle.kotlin.dsl.extra
 
 object Artifact {
   const val groupdId = "com.mercari.remotedata"
-  const val version = "1.0.0"
+  const val version = "1.0.1"
 }
 
 object MavenUrl {


### PR DESCRIPTION
This release includes:
- https://github.com/mercari/RemoteDataK/pull/42