### PR TITLE
Fix class loader to restore object from parcel

### DIFF
--- a/remotedata_android/src/main/java/com/mercari/remotedata/android/RemoteData.kt
+++ b/remotedata_android/src/main/java/com/mercari/remotedata/android/RemoteData.kt
@@ -4,7 +4,6 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
 import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.RawValue
 
 interface ErrorKind : Parcelable
 
@@ -79,7 +78,7 @@ sealed class RemoteData<out V : Any, out E : ErrorKind> : Parcelable {
     class Success<out V : Any>(val value: V) : RemoteData<V, Nothing>(), Complete {
 
         @Suppress("UNCHECKED_CAST")
-        private constructor(parcel: Parcel) : this(parcel.readValue(Thread.currentThread().contextClassLoader) as V)
+        private constructor(parcel: Parcel) : this(parcel.readValue(RemoteData::class.java.classLoader) as V)
 
         override fun component1(): V = value
 


### PR DESCRIPTION
`Thread.currentThread().contextClassLoader` may return a class loader which loads another app classes in some devices, causing ClassNotFoundException when restoring RemoteData.Success object from parcel. This is to fix this issue using a class loader belongs to the running app.